### PR TITLE
chore(deps): ignore askama_escape major/minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+    # askama_escape 0.15 switched HTML output from named entities
+    # (`&lt;`, `&gt;`, `&amp;`, `&quot;`, `&#x27;`) to numeric character
+    # references (`&#60;`, `&#62;`, `&#38;`, `&#34;`, `&#39;`). Both are
+    # valid HTML, but the change is user-visible in rendered bytes.
+    # Pin to 0.10.x until we deliberately migrate as a breaking change.
+    ignore:
+      - dependency-name: "askama_escape"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     labels: ["dependencies", "rust"]
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

`askama_escape` 0.15 changed HTML escape output from named entities (`&lt;`, `&gt;`, `&amp;`, `&quot;`, `&#x27;`) to numeric character references (`&#60;`, `&#62;`, `&#38;`, `&#34;`, `&#39;`). Both are valid HTML, but the change is user-visible in rendered bytes — anyone diffing rendered pages between releases would see a regression.

This pins `askama_escape` to the 0.10.x series in Dependabot config so PR #17 doesn't get re-opened. If we ever want to migrate to numeric-entity output, it'll be a deliberate breaking change in our own changelog.

Closes the rationale started in #17.

## Test Plan

- [x] Dependabot config validates as YAML
- [ ] Next Dependabot run does not re-open the askama_escape major bump PR

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co