### PR TITLE
release: v0.0.3 — lax mode, idempotent escape, perf recovery, dep sweep + RUSTSEC fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ci:
     name: Rust CI
-    uses: sebastienrousseau/pipelines/.github/workflows/rust-ci.yml@99a39f7d02e76beb2b935fa07b7cd6a46d8bbc65
+    uses: sebastienrousseau/pipelines/.github/workflows/rust-ci.yml@3df3a03745c05e13331e8f2cf9d46e2ea27b6358
     with:
       rust-version: 'stable'
       run-clippy: true
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -59,7 +59,7 @@ jobs:
     name: Coverage >= 98%
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
@@ -84,7 +84,7 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -61,9 +61,9 @@ jobs:
           # an underscore, which Jekyll would otherwise strip.
           touch target/doc/.nojekyll
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: target/doc
 
@@ -79,4 +79,4 @@ jobs:
       id-token: write
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: cargo publish
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (pre-`1.0.0`, breaking changes may occur in minor/patch releases and are
 called out explicitly below).
 
+## [0.0.3] - 2026-06-27
+
+### Fixed
+- HTML-entity escape is now idempotent — `escape(escape(x)) == escape(x)`.
+  Closes sebastienrousseau/static-site-generator#589. Defended by three
+  new property tests (#31): idempotency, no bare angle brackets in output,
+  every `&` begins a valid entity reference.
+- `Context::hash()` is no longer collision-prone (#30). Keys are sorted
+  before being fed to the hasher; the previous XOR aggregation could
+  produce identical digests for distinct `(key, value)` sets, returning
+  a stale render from the `render_page` cache. The same fix is applied
+  inside `hash_value` for nested `Value::Map` entries.
+
+### Added
+- Opt-in lax mode for unresolved template tags (#28). Strict mode remains
+  the default; lax mode emits `""` for any unresolved `{{key}}` and skips
+  the attached filter chain. New `tests/lax_mode.rs` matrix locks the
+  wire format with 10 strict/lax/differential cases (#32).
+
+### Changed
+- HTML escape path rewritten as an inline byte-indexed scan with
+  `matches!` over the OWASP 5-char set and bulk-flush via `push_str`
+  (#33). Recovers from the 3.4× regression introduced by the
+  `askama_escape` removal: `escape_heavy` 78.3 µs → **26.2 µs**
+  (−66.6 %), within ~12.5 % of the pre-ssg#589 SIMD baseline (23.3 µs)
+  while preserving the idempotency invariant.
+- `PERFORMANCE.md` re-stamped (#34) with date / toolchain / CPU on every
+  measurement; new Phase-#33 row added to the progression table; the
+  `escape_heavy` claim re-labelled to reflect the scalar entity-aware
+  path.
+
+### Removed
+- Direct dependency on `askama_escape`. The new inline escape path is
+  hand-rolled — no new runtime dependency added. See PERFORMANCE.md
+  for measured impact.
+
 ## [0.0.2] - 2026-04-26
 
 The `v0.0.2` cycle moved staticweaver from a Mustache-tier substituter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,16 +33,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "askama"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b8246bcbf8eb97abef10c2d92166449680d41d55c0fc6978a91dec2e3619608"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
  "askama_macros",
  "itoa",
@@ -53,12 +47,13 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9670bc84a28bb3da91821ef74226949ab63f1265aff7c751634f1dd0e6f97c"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
 dependencies = [
  "askama_parser",
  "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -70,18 +65,18 @@ dependencies = [
 
 [[package]]
 name = "askama_macros"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0756b45480437dded0565dfc568af62ccce146fb6cfe902e808ba86e445f44f"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
 dependencies = [
  "askama_derive",
 ]
 
 [[package]]
 name = "askama_parser"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0af3691ba3af77949c0b5a3925444b85cb58a0184cc7fec16c68ba2e7be868"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -108,15 +103,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -124,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -218,9 +213,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -233,25 +228,25 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -261,9 +256,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -318,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -482,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -499,9 +494,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -536,12 +531,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -646,16 +635,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -683,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -713,30 +706,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -779,9 +757,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -801,15 +779,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -921,12 +898,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -949,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -965,14 +936,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -980,16 +949,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -1062,13 +1021,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1079,16 +1037,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1113,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1131,9 +1083,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memo-map"
@@ -1149,9 +1101,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minijinja"
-version = "2.19.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
 dependencies = [
  "memo-map",
  "serde",
@@ -1159,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1355,16 +1307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,9 +1342,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1420,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -1451,14 +1393,14 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1515,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1544,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1567,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -1644,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1658,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -1670,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1789,12 +1731,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1873,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "similar"
@@ -1891,15 +1827,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1913,7 +1849,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "staticweaver"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "askama",
  "axum",
@@ -1938,9 +1874,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1974,7 +1910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2073,9 +2009,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2139,20 +2075,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2195,9 +2131,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -2219,15 +2155,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "untrusted"
@@ -2295,27 +2225,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2326,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2336,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2346,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2359,52 +2280,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2422,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2486,6 +2373,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2517,11 +2413,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2537,6 +2450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,6 +2466,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2561,10 +2486,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2579,6 +2516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +2532,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2603,6 +2552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,101 +2570,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "1.0.2"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -2719,9 +2598,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2742,18 +2621,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2762,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -2783,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,12 +69,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
 name = "askama_macros"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,7 +1916,6 @@ name = "staticweaver"
 version = "0.0.2"
 dependencies = [
  "askama",
- "askama_escape",
  "axum",
  "criterion",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ license = "MIT OR Apache-2.0"               # Dual licensing strategy
 description = """
 Small, safe, fast templating engine for Rust. Mustache-compatible \
 syntax with Tera-style expressions, inheritance with super(), 23 \
-built-in filters, custom filters/tests, pluggable loaders, SIMD HTML \
-escape that matches Askama, line:col error messages, zero unsafe code.
+built-in filters, custom filters/tests, pluggable loaders, idempotent \
+HTML escape, line:col error messages, zero unsafe code.
 """                                         # Short library description
 homepage = "https://staticweaver.com/"             # Project's homepage URL
 documentation = "https://staticweaver.com/documentation/index.html" # Doc URL
@@ -120,13 +120,6 @@ proptest = "1"
 # Required dependencies for building and running the project.
 
 fnv = "1.0"                                 # Fast non-cryptographic hash function
-
-# askama_escape is the same SIMD HTML-entity encoder Askama uses for
-# its built-in auto-escape, with a 5-character set (& < > " ') matching
-# our pre-existing contract. Auto-vectorised inner loop on long strings
-# (~3-10x faster than a scalar byte scan). Used only by
-# `escape_html_into`.
-askama_escape = "0.10"
 
 # reqwest powers the optional remote-template fetcher. Gated behind the
 # `remote-templates` feature so the core crate has no networking code in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "staticweaver"                       # The name of the library
-version = "0.0.2"                           # Current version of the crate
+version = "0.0.3"                           # Current version of the crate
 authors = ["StaticWeaver Contributors"]     # Library contributors
 edition = "2021"                            # Rust edition being used
 rust-version = "1.68"                       # MSRV (floor driven by thiserror 2.0 + regex 1.11 + serde_json 1.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ targets = ["x86_64-unknown-linux-gnu"]      # Default target platform for the do
 
 ## Warnings
 missing_copy_implementations = "warn"       # Warn if types can implement `Copy` but don’t
-missing_docs = "warn"                       # Warn if public items lack documentation
+missing_docs = "deny"                       # Deny missing docs — 100% doc coverage is a hard gate, not a CI-only check
 unstable_features = "warn"                  # Warn on the usage of unstable features
 unused_extern_crates = "warn"               # Warn about unused external crates
 unused_results = "warn"                     # Warn if a result type is unused (e.g., errors ignored)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ mockito = "1"
 # to keep performance claims honest.
 tera = { version = "1", default-features = false }
 minijinja = "2"
-askama = "0.15"
+askama = "0.16"
 
 # proptest powers the random-template robustness suite in
 # tests/proptest_parser.rs — every parser code path must NEVER panic

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -11,30 +11,56 @@ the engine caches at runtime.
 ## Headline numbers
 
 Full-quality `cargo bench --bench comparative` (Criterion, 2 s
-warm-up + 5 s measurement) on Apple M-series, after Phases D and H
-(latest measurement). Templates produce equivalent *output*; each
-engine uses its native syntax.
+warm-up + 5 s measurement) on Apple M-series, after Phases D and H.
+Templates produce equivalent *output*; each engine uses its native
+syntax.
 
 | Workload | staticweaver | Tera | Minijinja | Askama | vs Minijinja |
 | :--- | ---: | ---: | ---: | ---: | :--- |
 | `simple_sub` (1 tag) | **497 ns** | 388 ns | 591 ns | 95 ns | **+19%** (we win) |
 | `many_sub_32` (32 tags) | **12.85 µs** | 5.96 µs | 14.40 µs | 973 ns | **+11%** (we win) |
-| `escape_heavy` (10 KB body, 5% metachar) | **23.3 µs** | 77.8 µs | 24.3 µs | 23.2 µs | **+4%** (ties Askama too) |
+| `escape_heavy` (10 KB body, 5% metachar) | 26.2 µs† | 77.8 µs | 24.3 µs | 23.2 µs | −7.7% |
 | `each_100` (100 items) | 58.3 µs | 17.8 µs | 23.6 µs | 5.24 µs | −2.5× |
 | `each_1000` (1000 items) | 557 µs | 171 µs | 184 µs | 51.9 µs | −3.0× |
 | `if_chain` (nested conditionals) | 2.51 µs | 455 ns | 656 ns | 25.4 ns | −3.8× |
 | `filter_chain` (`trim \| upper`) | **1.03 µs** | 620 ns | 988 ns | 198 ns | **+5%** (we win) |
 
-**Wins or ties Minijinja on 4 / 7 workloads.** We **beat Tera on
-escape-heavy 3.3×** and **match Askama on the same workload**
-(23.3 µs vs 23.2 µs) — the SIMD escape path is fully competitive
-with Askama's compile-time codegen on long inputs.
+`simple_sub`, `many_sub_32`, `each_*`, `if_chain`, `filter_chain` measured
+2026-04 on Apple M-series, Rust stable. `escape_heavy` re-measured
+2026-06-27 on Apple M1 Pro, macOS 26.5.1, rustc 1.95.0
+(2026-04-14) — the value behind the † footnote — after the path
+rewrite described in the next section.
 
-The remaining 2.5–3.8× gap on loops and conditional chains is
-constant-factor per-tag overhead in the runtime AST walker; closing
-it would require a bytecode compiler. That was scoped as Phase D
-Option 1 and explicitly rejected to preserve the "small enough to
-read in an afternoon" pillar.
+**Wins or ties Minijinja on 4 / 7 workloads** and **beats Tera on
+escape-heavy 3.0×**. The remaining 2.5–3.8× gap on loops and
+conditional chains is constant-factor per-tag overhead in the
+runtime AST walker; closing it would require a bytecode compiler.
+That was scoped as Phase D Option 1 and explicitly rejected to
+preserve the "small enough to read in an afternoon" pillar.
+
+### † `escape_heavy` — about the path change
+
+v0.0.3 (this release) trades the old `askama_escape` SIMD path for
+an inline scalar entity-aware scanner. The change was forced by
+ssg#589: the SIMD path re-escaped already-formed entities
+(`&amp;` → `&amp;amp;`), breaking idempotency. The new path uses a
+byte-indexed fast scan with `matches!` over the OWASP 5-char set;
+safe runs flush via a single `push_str` (memcpy). Under
+`lto = true, opt-level = "z"` the loop autovectorises sufficiently
+to land at 26.2 µs — within ~12.5% of the dropped Askama parity
+(23.2 µs) while preserving the idempotency invariant that
+`escape(escape(x)) == escape(x)` (proptest-defended).
+
+| Path | `escape_heavy` (10 KB body, 5% metachar) |
+| :--- | ---: |
+| Pre-ssg#589 (v0.0.2, `askama_escape` SIMD) | 23.3 µs |
+| Post-ssg#589 scalar `char_indices` (pre-#33) | 78.3 µs (3.4× regression) |
+| **v0.0.3 inline byte-indexed fast path (#33)** | **26.2 µs** (within 12.5% of SIMD baseline) |
+
+A full SIMD recovery (custom AVX2/NEON `<>&"'` mask with entity
+lookahead) is scoped for v0.0.4 if benchmarks justify the
+complexity. The v0.0.3 scalar path is the right cost/benefit for a
+patch release: ~50 LOC, no new dependency, idempotency guaranteed.
 
 ## Phase D progression
 
@@ -48,6 +74,7 @@ The Phase D performance work, commit by commit:
 | **D4** | `set_value_str` — borrow key on update | each_1000 −12% (640µs → 563µs) |
 | **D6** | Allocation-free close-tag match in `extract_block` | if_chain −8% (2.6µs → 2.4µs) |
 | **D3** | Reuse `Value::String` buffer in `#each` (`set_value_string`) | each_100 −18% (67µs → 55µs) |
+| **#33 (v0.0.3)** | Inline byte-indexed escape fast path, post-`askama_escape` drop | escape_heavy −66.6% (78.3µs → 26.2µs) — recovers most of the D2 SIMD win while preserving ssg#589 idempotency |
 
 **Cumulative each_1000: 22.6 ms → 557 µs (~40× faster).** Numbers
 in the headline table above use the latest post-H measurement;
@@ -129,8 +156,11 @@ engine, and add the new function to the `criterion_group!` macro.
 
 Numbers above were measured on:
 
-* Apple M-series, macOS 25.4 (Darwin)
-* Rust stable (per `rust-toolchain.toml`)
+* Apple M-series (Phase D / H rows) and Apple M1 Pro (the v0.0.3
+  `escape_heavy` re-measurement)
+* macOS 25.4 (Phase D / H); macOS 26.5.1 (#33 re-measurement)
+* Rust stable per `rust-toolchain.toml`; #33 measured under rustc 1.95.0
+  (2026-04-14, aarch64-apple-darwin)
 * Release profile: `lto = true`, `codegen-units = 1`, `opt-level = "z"`
 
 Numbers will vary on other hardware. The *ratios* between engines

--- a/README.md
+++ b/README.md
@@ -671,17 +671,31 @@ cargo test --test snapshots          # 16 golden-output regressions
 
 | Surface | Hosted at | Built by | Trigger |
 | :--- | :--- | :--- | :--- |
-| API reference | [docs.rs/staticweaver](https://docs.rs/staticweaver) | docs.rs | `crates.io` publish |
+| API reference (release) | [docs.rs/staticweaver](https://docs.rs/staticweaver) | docs.rs | `crates.io` publish |
+| API reference (tip-of-`main`) | [doc.staticweaver.com](https://doc.staticweaver.com/) | `.github/workflows/docs.yml` → GitHub Pages (Pages-via-Actions, no `gh-pages` branch) | every push to `main` |
 | README + crate-level prose | [docs.rs/staticweaver](https://docs.rs/staticweaver) (front page) | `#![doc = include_str!("../README.md")]` in `src/lib.rs` | every `cargo doc` |
 | CHANGELOG / SECURITY / FAQ | This GitHub repo | -- | every push |
 
-The CI `docs` job builds documentation under `RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links"`, runs every doctest with `--all-features`, and enforces 100% example coverage. Publication itself is handled by docs.rs on every crates.io release — there is no `gh-pages` branch and no separate documentation workflow.
+Both the CI `Docs` job and the standalone `docs.yml` workflow build
+documentation under `RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"`,
+run every doctest with `--all-features`, and enforce **100 % example coverage**.
+Missing-docs warnings are upgraded to **`deny`** at the crate level
+(`Cargo.toml [lints.rust]`), so any undocumented public item fails
+`cargo build` directly — not just CI.
+
+Publication targets:
+- **Release docs** are built by docs.rs on every `cargo publish`.
+- **Tip-of-`main` docs** are built by `.github/workflows/docs.yml` and
+  deployed via `actions/deploy-pages` (GH-Pages-via-Actions). No
+  `gh-pages` branch exists; the artifact is uploaded directly and the
+  custom-domain `CNAME` is written on every deploy.
 
 ### CI
 
 | Workflow | Trigger | Purpose |
 | :--- | :--- | :--- |
 | `ci.yml` | push, PR | Clippy, fmt, test (Linux + macOS + Windows), coverage gate (98%), `cargo deny`, via reusable pipelines |
+| `docs.yml` | push to `main` | Build rustdoc + publish to GitHub Pages at `doc.staticweaver.com` |
 | `release.yml` | tag `v*.*.*` | Validate matrix (macOS + Linux + Windows), build artifacts, GitHub Release, crates.io publish |
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for signed commits and PR guidelines.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,45 @@
+# v0.0.3 — 2026-06-27
+
+This release closes a downstream regression and a latent correctness bug
+in the render cache. No public-API breakage.
+
+## Highlights
+
+- **HTML escape is idempotent.** Templates that double-escape (e.g.
+  `{{ x | safe | escape }}` patterns or pre-escaped fixtures) now produce
+  byte-identical output regardless of how many escape passes ran. Unblocks
+  sebastienrousseau/static-site-generator#589.
+- **Context hash is collision-safe.** The cache key for `render_page` no
+  longer hashes via order-independent XOR. Sort-then-hash eliminates a
+  class of stale-render bugs that could surface under heavy contextual
+  re-keying.
+- **Lax mode** for unresolved tags (#28) — opt-in. Strict mode unchanged.
+
+## Performance — `escape_heavy`
+
+The `askama_escape` removal (committed at the head of `feat/v0.0.3`)
+traded the old SIMD escape path for a scalar entity-aware scanner that
+preserves the ssg#589 idempotency invariant. The cost was real:
+`escape_heavy` regressed from 23.3 µs → 78.3 µs (3.4×).
+
+v0.0.3 recovers most of it. The escape function is rewritten as an
+inline byte-indexed `matches!` scan over the OWASP 5-char set with
+bulk-flush via `push_str`; under `lto = true` the loop autovectorises
+sufficiently to land at **26.2 µs** — within ~12.5 % of the dropped
+SIMD baseline. No new runtime dependency was added.
+
+See [PERFORMANCE.md](PERFORMANCE.md) for the full table, the per-phase
+progression, and the toolchain / CPU stamp.
+
+## Upgrade
+
+```toml
+[dependencies]
+staticweaver = "0.0.3"
+```
+
+No code changes required.
+
 # `staticweaver` v0.0.2
 
 `v0.0.2` graduates `staticweaver` from a Mustache-tier substituter into a **full

--- a/src/context.rs
+++ b/src/context.rs
@@ -219,16 +219,17 @@ fn hash_value<H: Hasher>(v: &Value, h: &mut H) {
         }
         Value::Map(m) => {
             5u8.hash(h);
-            // XOR per-entry hashes — order-independent (FnvHashMap
-            // iteration order is unspecified).
-            let mut acc: u64 = 0;
-            for (k, val) in m {
-                let mut sub = DefaultHasher::new();
-                k.hash(&mut sub);
-                hash_value(val, &mut sub);
-                acc ^= sub.finish();
+            // Sort keys before feeding into the hasher: XOR aggregation
+            // is order-independent but collision-prone (issue #30).
+            // `FnvHashMap` iteration order is unspecified, so we must
+            // sort to keep the hash deterministic.
+            m.len().hash(h);
+            let mut keys: Vec<&String> = m.keys().collect();
+            keys.sort_unstable();
+            for k in keys {
+                k.hash(h);
+                hash_value(&m[k], h);
             }
-            acc.hash(h);
         }
     }
 }
@@ -295,9 +296,12 @@ impl Context {
         }
     }
 
-    /// Stable, iteration-order-independent hash of every entry. XOR
-    /// combines per-entry hashes so equal logical contexts always hash
-    /// equal — the `render_page` cache relies on this.
+    /// Stable, iteration-order-independent hash of every entry.
+    ///
+    /// Keys are sorted before being fed to the hasher (issue #30). The
+    /// previous XOR aggregation was order-independent but collision-prone:
+    /// two distinct `(key, value)` sets could XOR to the same `u64`,
+    /// returning a stale render from the `render_page` cache.
     ///
     /// # Examples
     ///
@@ -311,14 +315,15 @@ impl Context {
     /// ```
     #[must_use]
     pub fn hash(&self) -> u64 {
-        let mut acc: u64 = 0;
-        for (key, value) in &self.elements {
-            let mut h = DefaultHasher::new();
-            key.hash(&mut h);
-            hash_value(value, &mut h);
-            acc ^= h.finish();
+        let mut h = DefaultHasher::new();
+        self.elements.len().hash(&mut h);
+        let mut keys: Vec<&String> = self.elements.keys().collect();
+        keys.sort_unstable();
+        for k in keys {
+            k.hash(&mut h);
+            hash_value(&self.elements[k], &mut h);
         }
-        acc
+        h.finish()
     }
 
     /// Sets a string-typed entry. Backwards-compatible with the pre-Value
@@ -1007,5 +1012,92 @@ mod tests {
         // splitn(2, '.') on empty string yields [""]
         // elements.get("") returns None.
         assert_eq!(ctx.get_path(""), None);
+    }
+
+    // ── #30: hash collision-resistance ──────────────────────────────
+
+    #[test]
+    fn hash_distinguishes_swapped_values() {
+        // The classic XOR-aggregation failure mode: swap two values
+        // between two keys. Sort-then-hash distinguishes the resulting
+        // contexts; XOR aggregation may not.
+        let mut a = Context::new();
+        a.set("k1".to_string(), "v1".to_string());
+        a.set("k2".to_string(), "v2".to_string());
+
+        let mut b = Context::new();
+        b.set("k1".to_string(), "v2".to_string());
+        b.set("k2".to_string(), "v1".to_string());
+
+        assert_ne!(a.hash(), b.hash());
+    }
+
+    #[test]
+    fn hash_is_insertion_order_independent() {
+        // Equal logical sets must hash equal regardless of insertion
+        // order — the `render_page` cache relies on this invariant.
+        let mut a = Context::new();
+        a.set("alpha".to_string(), "1".to_string());
+        a.set("beta".to_string(), "2".to_string());
+        a.set("gamma".to_string(), "3".to_string());
+
+        let mut b = Context::new();
+        b.set("gamma".to_string(), "3".to_string());
+        b.set("alpha".to_string(), "1".to_string());
+        b.set("beta".to_string(), "2".to_string());
+
+        assert_eq!(a.hash(), b.hash());
+    }
+
+    #[test]
+    fn hash_distinguishes_empty_from_single_entry() {
+        let empty = Context::new();
+        let mut one = Context::new();
+        one.set("k".to_string(), "v".to_string());
+        assert_ne!(empty.hash(), one.hash());
+    }
+
+    #[test]
+    fn hash_nested_map_is_order_independent() {
+        // Value::Map iteration order is unspecified (FnvHashMap).
+        // Sort-then-hash inside hash_value() keeps the digest stable
+        // for equal maps inserted in different orders.
+        let mut m1 = FnvHashMap::default();
+        let _ = m1.insert("a".to_string(), Value::Number(1));
+        let _ = m1.insert("b".to_string(), Value::Number(2));
+        let _ = m1.insert("c".to_string(), Value::Number(3));
+
+        let mut m2 = FnvHashMap::default();
+        let _ = m2.insert("c".to_string(), Value::Number(3));
+        let _ = m2.insert("a".to_string(), Value::Number(1));
+        let _ = m2.insert("b".to_string(), Value::Number(2));
+
+        let mut a = Context::new();
+        a.set_value("m".to_string(), Value::Map(m1));
+        let mut b = Context::new();
+        b.set_value("m".to_string(), Value::Map(m2));
+
+        assert_eq!(a.hash(), b.hash());
+    }
+
+    #[test]
+    fn hash_nested_map_distinguishes_swapped_values() {
+        // Same swap-pattern test as `hash_distinguishes_swapped_values`
+        // but inside a `Value::Map`, exercising the inner hash_value
+        // path.
+        let mut m1 = FnvHashMap::default();
+        let _ = m1.insert("k1".to_string(), Value::from("v1"));
+        let _ = m1.insert("k2".to_string(), Value::from("v2"));
+
+        let mut m2 = FnvHashMap::default();
+        let _ = m2.insert("k1".to_string(), Value::from("v2"));
+        let _ = m2.insert("k2".to_string(), Value::from("v1"));
+
+        let mut a = Context::new();
+        a.set_value("m".to_string(), Value::Map(m1));
+        let mut b = Context::new();
+        b.set_value("m".to_string(), Value::Map(m2));
+
+        assert_ne!(a.hash(), b.hash());
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -542,6 +542,14 @@ pub struct Engine {
     /// assert_eq!(engine.autoescape_extensions, vec![".html"]);
     /// ```
     pub autoescape_extensions: Vec<String>,
+    /// When `true`, an unresolved `{{key}}` substitution emits an
+    /// empty string instead of aborting the render with
+    /// `EngineError::Render("Unresolved template tag: <key>")`.
+    /// Defaults to `false` (strict). Mirrors Jinja2's "undefined"
+    /// mode and lets sites whose page templates reference variables
+    /// that not every page supplies build without per-page shims.
+    /// Toggle via [`Engine::with_lax_undefined`]. Issue #28.
+    pub lax_undefined: bool,
 }
 
 // `Engine` is mostly auto-debuggable, but `custom_filters` carries
@@ -566,6 +574,7 @@ impl std::fmt::Debug for Engine {
             // dyn-trait field — Debug just shows the placeholder.
             .field("loader", &"<dyn TemplateLoader>")
             .field("autoescape_extensions", &self.autoescape_extensions)
+            .field("lax_undefined", &self.lax_undefined)
             .finish()
     }
 }
@@ -600,6 +609,7 @@ impl Engine {
                 template_path,
             ))),
             autoescape_extensions: Vec::new(),
+            lax_undefined: false,
         }
     }
 
@@ -653,6 +663,7 @@ impl Engine {
             custom_tests: HashMap::new(),
             loader,
             autoescape_extensions: Vec::new(),
+            lax_undefined: false,
         }
     }
 
@@ -796,6 +807,32 @@ impl Engine {
     #[must_use]
     pub fn with_html_escape(mut self, enable: bool) -> Self {
         self.escape_html = enable;
+        self
+    }
+
+    /// Sets whether unresolved `{{key}}` substitutions abort the
+    /// render (strict, default) or emit an empty string (lax).
+    ///
+    /// Lax mode mirrors Jinja2's "undefined" behaviour and lets
+    /// sites whose page templates reference variables that not every
+    /// page supplies build without per-page shims. Issue #28.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use staticweaver::{Context, Engine};
+    /// use std::time::Duration;
+    /// let mut engine = Engine::new("", Duration::from_secs(60))
+    ///     .with_lax_undefined(true);
+    /// let ctx = Context::new();
+    /// assert_eq!(
+    ///     engine.render_template("hello {{name}}", &ctx).unwrap(),
+    ///     "hello ",
+    /// );
+    /// ```
+    #[must_use]
+    pub fn with_lax_undefined(mut self, lax: bool) -> Self {
+        self.lax_undefined = lax;
         self
     }
 
@@ -1623,12 +1660,22 @@ impl Engine {
                 .filter(|(name, _)| !name.is_empty())
                 .collect();
 
-            let value = active.get_path(lookup).ok_or_else(|| {
-                EngineError::Render(format!(
-                    "Unresolved template tag: {lookup}{}",
-                    pos_suffix(origin, lookup)
-                ))
-            })?;
+            let value = match active.get_path(lookup) {
+                Some(v) => v,
+                None => {
+                    if self.lax_undefined {
+                        // Issue #28: emit nothing for unresolved tags.
+                        // Skip the filter chain — applying e.g. `| date`
+                        // to an empty value would error anyway.
+                        rest = after_tag;
+                        continue;
+                    }
+                    return Err(EngineError::Render(format!(
+                        "Unresolved template tag: {lookup}{}",
+                        pos_suffix(origin, lookup)
+                    )));
+                }
+            };
             let mut rendered = value.to_string();
 
             // A trailing `safe` filter marks the value as already-safe
@@ -8005,5 +8052,32 @@ mod tests {
                 panic!("expected InvalidTemplate, got {other:?}")
             }
         }
+    }
+
+    #[test]
+    fn lax_mode_substitutes_empty_for_unresolved_tags() {
+        // Regression for sebastienrousseau/staticweaver#28.
+        // When lax_undefined is true, an undefined {{key}} emits "",
+        // letting the build proceed instead of aborting.
+        let engine = Engine::new("", Duration::from_secs(60))
+            .with_lax_undefined(true);
+        let ctx = Context::new();
+        let out = engine
+            .render_template("hello {{name}} world", &ctx)
+            .unwrap();
+        assert_eq!(out, "hello  world");
+    }
+
+    #[test]
+    fn strict_mode_still_errors_on_unresolved_tags() {
+        // Default is strict (lax_undefined = false). Pre-existing
+        // behaviour must not regress.
+        let engine = Engine::new("", Duration::from_secs(60));
+        let ctx = Context::new();
+        let err = engine.render_template("{{name}}", &ctx).unwrap_err();
+        assert!(
+            format!("{err}").contains("Unresolved template tag"),
+            "strict mode should still raise; got: {err}"
+        );
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3496,40 +3496,62 @@ fn split_else<'a>(
 /// with a 32-byte cap (the longest HTML5 named ref,
 /// `CounterClockwiseContourIntegral`, is 31 chars).
 fn escape_html_into(s: &str, out: &mut String) {
-    // ssg#589: skip already-formed entity references so a value that
-    // is already `AI &amp; Payments` doesn't become `AI &amp;amp;
-    // Payments` on a second pass through the engine.
-    //
-    // Trades the askama_escape SIMD path for a scalar char scan —
-    // entity-aware escaping needs lookahead the SIMD implementation
-    // doesn't provide. Performance cost is acceptable: the metadata
-    // / body content this scans is small per page and the pipeline
-    // is template-bound, not escape-bound.
+    // Fast-path byte scan (issue #33): the OWASP 5 metacharacters
+    // (`<`, `>`, `&`, `"`, `'`) are all ASCII, so byte-indexed iteration
+    // is UTF-8-safe — every multi-byte sequence has leading byte ≥ 0x80
+    // and continuation bytes 0x80..=0xBF, none of which can match a
+    // metacharacter byte. Safe runs flush via a single `push_str`
+    // (memcpy) instead of char-by-char appends; the `matches!` arm
+    // autovectorises under `lto = true, opt-level = "z"` to within
+    // ~6× of the pre-ssg#589 `askama_escape` SIMD path while
+    // preserving entity-awareness.
     out.reserve(s.len());
     let bytes = s.as_bytes();
-    let mut chars = s.char_indices().peekable();
-    while let Some((i, c)) = chars.next() {
-        match c {
-            '&' => {
+    let mut start: usize = 0;
+    let mut i: usize = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if !matches!(b, b'<' | b'>' | b'&' | b'"' | b'\'') {
+            i += 1;
+            continue;
+        }
+        if start < i {
+            out.push_str(&s[start..i]);
+        }
+        match b {
+            b'&' => {
                 if let Some(end) = scan_existing_entity(bytes, i) {
+                    // Preserve an already-formed `&name;` / `&#NN;` /
+                    // `&#xNN;` verbatim — ssg#589 idempotency invariant.
                     out.push_str(&s[i..end]);
-                    // Advance the char iterator past the entity.
-                    while let Some(&(j, _)) = chars.peek() {
-                        if j >= end {
-                            break;
-                        }
-                        let _ = chars.next();
-                    }
+                    i = end;
                 } else {
                     out.push_str("&amp;");
+                    i += 1;
                 }
             }
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&#x27;"),
-            other => out.push(other),
+            b'<' => {
+                out.push_str("&lt;");
+                i += 1;
+            }
+            b'>' => {
+                out.push_str("&gt;");
+                i += 1;
+            }
+            b'"' => {
+                out.push_str("&quot;");
+                i += 1;
+            }
+            b'\'' => {
+                out.push_str("&#x27;");
+                i += 1;
+            }
+            _ => unreachable!(),
         }
+        start = i;
+    }
+    if start < bytes.len() {
+        out.push_str(&s[start..]);
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3490,12 +3490,11 @@ fn split_else<'a>(
 /// named/numeric entities. Single-quote uses the numeric `&#x27;` form so
 /// the output stays valid inside both HTML and XML attributes.
 ///
-/// Byte-level scan: iterate over `s.as_bytes()`, flush clean runs via
-/// Append `s` to `out` with `& < > " '` substituted for their HTML
-/// entities. Same five-character set as Askama's `Html` escaper.
-/// Delegates to `askama_escape`, which auto-vectorises the inner loop
-/// with SIMD (SSE4.2 / AVX2 / NEON depending on target) for a ~3-10×
-/// speedup on long strings vs the scalar byte scan we used previously.
+/// Idempotent (ssg#589): already-formed entity references — `&name;`,
+/// `&#NN;`, `&#xNN;` — are preserved verbatim instead of getting their
+/// leading `&` re-escaped to `&amp;`. The lookup uses `scan_existing_entity`
+/// with a 32-byte cap (the longest HTML5 named ref,
+/// `CounterClockwiseContourIntegral`, is 31 chars).
 fn escape_html_into(s: &str, out: &mut String) {
     // ssg#589: skip already-formed entity references so a value that
     // is already `AI &amp; Payments` doesn't become `AI &amp;amp;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3497,15 +3497,92 @@ fn split_else<'a>(
 /// with SIMD (SSE4.2 / AVX2 / NEON depending on target) for a ~3-10×
 /// speedup on long strings vs the scalar byte scan we used previously.
 fn escape_html_into(s: &str, out: &mut String) {
-    use std::fmt::Write as _;
+    // ssg#589: skip already-formed entity references so a value that
+    // is already `AI &amp; Payments` doesn't become `AI &amp;amp;
+    // Payments` on a second pass through the engine.
+    //
+    // Trades the askama_escape SIMD path for a scalar char scan —
+    // entity-aware escaping needs lookahead the SIMD implementation
+    // doesn't provide. Performance cost is acceptable: the metadata
+    // / body content this scans is small per page and the pipeline
+    // is template-bound, not escape-bound.
     out.reserve(s.len());
-    // `write!` against `String` is infallible; the result is discarded
-    // explicitly to satisfy `unused_results`.
-    let _ = write!(
-        out,
-        "{}",
-        askama_escape::escape(s, askama_escape::Html)
-    );
+    let bytes = s.as_bytes();
+    let mut chars = s.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        match c {
+            '&' => {
+                if let Some(end) = scan_existing_entity(bytes, i) {
+                    out.push_str(&s[i..end]);
+                    // Advance the char iterator past the entity.
+                    while let Some(&(j, _)) = chars.peek() {
+                        if j >= end {
+                            break;
+                        }
+                        let _ = chars.next();
+                    }
+                } else {
+                    out.push_str("&amp;");
+                }
+            }
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#x27;"),
+            other => out.push(other),
+        }
+    }
+}
+
+/// Returns `Some(end)` if `bytes[start..]` begins with a syntactically
+/// valid HTML entity reference (`&name;`, `&#NN;`, or `&#xNN;`),
+/// otherwise `None`. Caps the lookahead at 32 bytes — the longest
+/// HTML5 named character reference (`CounterClockwiseContourIntegral`)
+/// fits comfortably under that.
+fn scan_existing_entity(bytes: &[u8], start: usize) -> Option<usize> {
+    debug_assert_eq!(bytes[start], b'&');
+    let cap = bytes.len().min(start + 32);
+    let mut j = start + 1;
+    if j >= cap {
+        return None;
+    }
+    if bytes[j] == b'#' {
+        // Numeric: &#NN; or &#xNN; / &#XNN;.
+        j += 1;
+        if j >= cap {
+            return None;
+        }
+        let is_hex = bytes[j] == b'x' || bytes[j] == b'X';
+        if is_hex {
+            j += 1;
+        }
+        let digits_start = j;
+        while j < cap
+            && ((is_hex && bytes[j].is_ascii_hexdigit())
+                || (!is_hex && bytes[j].is_ascii_digit()))
+        {
+            j += 1;
+        }
+        if j == digits_start {
+            return None;
+        }
+        if j < cap && bytes[j] == b';' {
+            return Some(j + 1);
+        }
+        return None;
+    }
+    // Named: &name; where name is ASCII alphanumeric (a-z, A-Z, 0-9).
+    let name_start = j;
+    while j < cap && bytes[j].is_ascii_alphanumeric() {
+        j += 1;
+    }
+    if j == name_start {
+        return None;
+    }
+    if j < cap && bytes[j] == b';' {
+        return Some(j + 1);
+    }
+    None
 }
 
 #[cfg(test)]
@@ -8079,5 +8156,51 @@ mod tests {
             format!("{err}").contains("Unresolved template tag"),
             "strict mode should still raise; got: {err}"
         );
+    }
+
+    #[test]
+    fn escape_html_preserves_existing_named_entities() {
+        // Regression for sebastienrousseau/static-site-generator#589.
+        // `AI &amp; Payments` must stay `AI &amp; Payments`, not
+        // become `AI &amp;amp; Payments`.
+        let engine = Engine::new("", Duration::from_secs(60));
+        let mut ctx = Context::new();
+        ctx.set("x".to_string(), "AI &amp; Payments".to_string());
+        let out = engine.render_template("{{x}}", &ctx).unwrap();
+        assert_eq!(out, "AI &amp; Payments");
+    }
+
+    #[test]
+    fn escape_html_preserves_existing_numeric_entities() {
+        // Numeric entity refs (decimal AND hex) must be preserved.
+        let engine = Engine::new("", Duration::from_secs(60));
+        let mut ctx = Context::new();
+        ctx.set("x".to_string(), "copy &#169; hex &#xA9;".to_string());
+        let out = engine.render_template("{{x}}", &ctx).unwrap();
+        assert_eq!(out, "copy &#169; hex &#xA9;");
+    }
+
+    #[test]
+    fn escape_html_still_escapes_bare_ampersand_at_eof() {
+        // A bare `&` with no terminator must still escape — the
+        // entity scanner is allowed to bail and fall through.
+        let engine = Engine::new("", Duration::from_secs(60));
+        let mut ctx = Context::new();
+        ctx.set("x".to_string(), "AT&T R&D".to_string());
+        let out = engine.render_template("{{x}}", &ctx).unwrap();
+        assert_eq!(out, "AT&amp;T R&amp;D");
+    }
+
+    #[test]
+    fn escape_html_handles_mixed_bare_and_escaped() {
+        // Mix: bare `&` → `&amp;`, already-escaped `&amp;` stays.
+        let engine = Engine::new("", Duration::from_secs(60));
+        let mut ctx = Context::new();
+        ctx.set(
+            "x".to_string(),
+            "AT&T owns &amp; and AT&amp;T too".to_string(),
+        );
+        let out = engine.render_template("{{x}}", &ctx).unwrap();
+        assert_eq!(out, "AT&amp;T owns &amp; and AT&amp;T too");
     }
 }

--- a/tests/lax_mode.rs
+++ b/tests/lax_mode.rs
@@ -1,0 +1,133 @@
+// Copyright © 2024-2026 StaticWeaver. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Lax-mode wire-format matrix.
+//!
+//! Locks the user-visible behaviour of `Engine::with_lax_undefined(true)`
+//! (issue #28) so a future refactor cannot silently change what a
+//! template build produces when a variable is missing.
+//!
+//! The contract:
+//!   * **Strict** (default): an unresolved `{{x}}` returns
+//!     `EngineError::Render` with a `line N, column M` suffix.
+//!   * **Lax**: an unresolved `{{x}}` emits the empty string and the
+//!     render continues. The filter chain attached to the unresolved
+//!     tag is skipped.
+//!
+//! Snapshot-style assertions (`assert_eq!` on full output) deliberately
+//! pin every byte, so a whitespace or escape change in the substitution
+//! path is caught here, not by a downstream user.
+
+use staticweaver::{Context, Engine};
+use std::time::Duration;
+
+fn lax() -> Engine {
+    Engine::new("", Duration::from_secs(60)).with_lax_undefined(true)
+}
+
+fn strict() -> Engine {
+    Engine::new("", Duration::from_secs(60))
+}
+
+#[test]
+fn lax_undefined_var_emits_empty() {
+    let ctx = Context::new();
+    let out = lax().render_template("a={{x}}b", &ctx).unwrap();
+    assert_eq!(out, "a=b");
+}
+
+#[test]
+fn strict_undefined_var_errors_with_line_col() {
+    let ctx = Context::new();
+    let err = strict().render_template("a={{x}}b", &ctx).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("Unresolved template tag: x"), "got: {msg}",);
+    assert!(msg.contains("line 1"), "got: {msg}");
+    assert!(msg.contains("column"), "got: {msg}");
+}
+
+#[test]
+fn lax_defined_var_renders_normally() {
+    // Lax must not change the substitution path when the var resolves.
+    let mut ctx = Context::new();
+    ctx.set("x".to_string(), "hi".to_string());
+    let out = lax().render_template("a={{x}}b", &ctx).unwrap();
+    assert_eq!(out, "a=hib");
+}
+
+#[test]
+fn lax_undefined_nested_path_emits_empty() {
+    // `{{user.name}}` with no `user` at all must resolve to "" under lax.
+    let ctx = Context::new();
+    let out = lax().render_template("a={{user.name}}b", &ctx).unwrap();
+    assert_eq!(out, "a=b");
+}
+
+#[test]
+fn lax_multiple_undefined_vars_all_emit_empty() {
+    let ctx = Context::new();
+    let out =
+        lax().render_template("[{{a}}|{{b}}|{{c}}]", &ctx).unwrap();
+    assert_eq!(out, "[||]");
+}
+
+#[test]
+fn lax_mixed_defined_and_undefined() {
+    let mut ctx = Context::new();
+    ctx.set("a".to_string(), "1".to_string());
+    ctx.set("c".to_string(), "3".to_string());
+    let out =
+        lax().render_template("[{{a}}|{{b}}|{{c}}]", &ctx).unwrap();
+    assert_eq!(out, "[1||3]");
+}
+
+#[test]
+fn lax_undefined_tag_skips_attached_filters() {
+    // Filter chain on an unresolved tag must be skipped — applying
+    // e.g. `| uppercase` to the empty substitution would still be "",
+    // but more importantly applying a typed filter (`| number_format`)
+    // to a missing key would otherwise error and defeat the point of
+    // lax mode.
+    let ctx = Context::new();
+    let out = lax()
+        .render_template(
+            r#"before [{{missing | uppercase}}] after"#,
+            &ctx,
+        )
+        .unwrap();
+    assert_eq!(out, "before [] after");
+}
+
+// ── Differential: strict errors AND lax succeeds on the same input ──
+
+#[test]
+fn differential_strict_errors_lax_succeeds() {
+    let ctx = Context::new();
+    let template = "[{{a}}|{{b}}|{{c}}]";
+    assert!(strict().render_template(template, &ctx).is_err());
+    assert_eq!(lax().render_template(template, &ctx).unwrap(), "[||]");
+}
+
+#[test]
+fn differential_defined_input_outputs_match() {
+    // When every variable resolves, strict and lax must produce the
+    // same bytes — lax is strictly additive, never subtractive.
+    let mut ctx = Context::new();
+    ctx.set("a".to_string(), "1".to_string());
+    ctx.set("b".to_string(), "2".to_string());
+    let template = "[{{a}}|{{b}}]";
+    let s = strict().render_template(template, &ctx).unwrap();
+    let l = lax().render_template(template, &ctx).unwrap();
+    assert_eq!(s, l);
+    assert_eq!(s, "[1|2]");
+}
+
+#[test]
+fn lax_undefined_does_not_break_escape() {
+    // A defined value that contains HTML must still escape even when
+    // the engine is in lax mode.
+    let mut ctx = Context::new();
+    ctx.set("x".to_string(), "<b>hi</b>".to_string());
+    let out = lax().render_template("{{x}}", &ctx).unwrap();
+    assert_eq!(out, "&lt;b&gt;hi&lt;/b&gt;");
+}

--- a/tests/proptest_parser.rs
+++ b/tests/proptest_parser.rs
@@ -114,4 +114,78 @@ proptest! {
         let ctx = Context::new();
         let _ = e.render_template(&template, &ctx);
     }
+
+    // ── #31: HTML-escape idempotency invariant ──────────────────────
+    // Regression guard for sebastienrousseau/static-site-generator#589.
+    // The escape function must be a fixed point: feeding rendered
+    // output back through the engine as the value of `{{x}}` must
+    // produce byte-identical output. If a future refactor re-introduces
+    // double-encoding (`&amp;` → `&amp;amp;`), these properties fail
+    // on randomly generated inputs that include `&`, `<`, `>`, `"`, `'`.
+
+    /// Rendering `{{x}}` then feeding the output back in as `x`
+    /// must produce the same bytes. Covers the entity-preservation
+    /// branch (`&amp;`, `&#169;`, `&#xA9;` etc.).
+    #[test]
+    fn html_escape_is_idempotent(
+        s in "\\PC{0,500}",
+    ) {
+        let e = engine();
+        let mut ctx = Context::new();
+        ctx.set("x".to_string(), s);
+        let once = e.render_template("{{x}}", &ctx).expect("render");
+        let mut ctx2 = Context::new();
+        ctx2.set("x".to_string(), once.clone());
+        let twice = e.render_template("{{x}}", &ctx2).expect("re-render");
+        prop_assert_eq!(once, twice);
+    }
+
+    /// Rendered output of `{{x}}` over arbitrary input must never
+    /// contain a bare `<` or `>` — both must escape unconditionally.
+    /// The template literal itself has no metacharacters, so any
+    /// `<`/`>` in the output came from `x` and must have been escaped.
+    #[test]
+    fn html_escape_never_emits_bare_angle_brackets(
+        s in "\\PC{0,500}",
+    ) {
+        let e = engine();
+        let mut ctx = Context::new();
+        ctx.set("x".to_string(), s);
+        let out = e.render_template("{{x}}", &ctx).expect("render");
+        prop_assert!(!out.contains('<'), "bare `<` in output: {:?}", out);
+        prop_assert!(!out.contains('>'), "bare `>` in output: {:?}", out);
+    }
+
+    /// Every `&` in the output must begin a syntactically valid
+    /// entity reference (`&name;`, `&#NN;`, `&#xNN;`) within the
+    /// 32-byte cap enforced by `scan_existing_entity`. A bare `&`
+    /// is a regression.
+    #[test]
+    fn html_escape_every_ampersand_starts_a_valid_entity(
+        s in "\\PC{0,500}",
+    ) {
+        let e = engine();
+        let mut ctx = Context::new();
+        ctx.set("x".to_string(), s);
+        let out = e.render_template("{{x}}", &ctx).expect("render");
+        let bytes = out.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'&' {
+                let cap = bytes.len().min(i + 33);
+                let mut j = i + 1;
+                while j < cap && bytes[j] != b';' {
+                    j += 1;
+                }
+                prop_assert!(
+                    j < cap && bytes[j] == b';',
+                    "bare `&` (no terminator) at byte {} in {:?}",
+                    i, out,
+                );
+                i = j + 1;
+            } else {
+                i += 1;
+            }
+        }
+    }
 }


### PR DESCRIPTION
# release: v0.0.3 — full change manifest vs `main`

Six commits, 13 files changed, **+925 / -421** lines. No public-API
breakage. Pre-1.0 patch release.

## Commit chain (`origin/main..feat/v0.0.3`)

| SHA | Message |
|---|---|
| `2a3610b` | feat: opt-in lax mode for unresolved template tags (#28) |
| `4f7469d` | fix: make HTML-entity escape idempotent (closes sebastienrousseau/static-site-generator#589) |
| `19f6be9` | chore(deps): drop askama_escape (no longer used) |
| `8bf88c2` | chore(release): v0.0.3 |
| `1bdf6b9` | chore(deps): sweep Dependabot backlog + fix RUSTSEC-2026-0185 |
| `20cd53f` | docs: enforce 100% doc coverage at compile time + publish to GH Pages |

## Feature work

### Lax mode for unresolved tags — closes #28
Opt-in `Engine::with_lax_undefined(true)`. Strict mode (the default)
unchanged. Lax mode emits `""` for unresolved `{{key}}` and skips the
attached filter chain. **10-case `tests/lax_mode.rs` matrix** locks
the strict/lax/differential wire format (#32).

### HTML escape idempotency — closes ssg#589
`escape(escape(x)) == escape(x)` is now a defended invariant.
Already-formed entity references (`&amp;`, `&#169;`, `&#xA9;`,
`&CounterClockwiseContourIntegral;`) are preserved instead of getting
re-escaped. **3 new property tests in `tests/proptest_parser.rs`** (#31):
idempotency, no bare angle brackets, every `&` begins a valid entity.

### `Context::hash()` collision fix — closes #30
Sort-then-hash replaces XOR aggregation. The old XOR could produce
identical digests for distinct `(key, value)` sets, returning a stale
render from the `render_page` cache. Same fix applied inside
`hash_value` for nested `Value::Map` entries. **5 new unit tests**.

## Performance

### `escape_heavy` — closes #33

| Path | `escape_heavy` (10 KB body, 5 % metachar) |
| :--- | ---: |
| Pre-ssg#589 (v0.0.2, `askama_escape` SIMD) | 23.3 µs |
| Post-ssg#589 scalar `char_indices` (regression) | 78.3 µs (3.4× slower) |
| **v0.0.3 inline byte-indexed fast path** | **26.2 µs** (−66.6 % recovery) |

Within ~12.5 % of the dropped SIMD baseline while preserving the
ssg#589 idempotency invariant. `matches!` over the OWASP 5-char set
with bulk-flush via `push_str`; autovectorises under `lto = true`.
**No new runtime dependency.**

### `PERFORMANCE.md` re-stamped — closes #34
Every numeric claim now carries `(measured YYYY-MM-DD on <rustc> /
<cpu> / <os>)`. Phase-#33 row added to the per-phase progression
table. `escape_heavy` re-labelled to reflect the scalar entity-aware
path (no longer SIMD).

## Dependency sweep (7 PRs absorbed)

Compresses the v0.0.5-planned sweep into v0.0.3 to unblock the audit
job. All seven branches deleted from origin.

| PR | Bump | Disposition |
|---|---|---|
| #20 | `actions/configure-pages` v5 → v6 | Replayed in `1bdf6b9` |
| #21 | `actions/upload-pages-artifact` v3 → v5 | Replayed |
| #22 | `actions/deploy-pages` v4 → v5 | Replayed |
| #23 | `askama` (dev-dep) 0.15.6 → 0.16.0 | Replayed — comparative bench compiles + runs |
| #25 | cargo minor-and-patch group | Replayed via `cargo update` |
| #26 | `pipelines/rust-ci.yml` SHA bump | Replayed (`99a39f7` → `3df3a03`) |
| #27 | `actions/checkout` v6 → v7 | Replayed across ci.yml, docs.yml, release.yml |

## Vulnerability remediation — **RUSTSEC-2026-0185**

> **quinn-proto 0.11.14** — Remote memory exhaustion from unbounded
> out-of-order stream reassembly. CVSS 7.5 (network / low complexity
> / no privileges / availability impact).

Fix: `quinn-proto 0.11.14 → 0.11.15` via `cargo update`. Transitive
through reqwest/axum; not a direct dep. Confirmed locally with
`cargo audit` (exit 0) and by the **`Rust CI / Audit` job now
SUCCESS** (was FAIL before this PR).

## Documentation hardening

- `[lints.rust] missing_docs = "deny"` (was `"warn"`). 100 % doc
  coverage is now a `cargo build` failure, not just a CI check.
- Verified locally: **106 / 106 items documented, 83 / 83 examples**
  rendered, all 5 source files at 100.0 %.
- README "Documentation" section rewritten to match reality:
  `.github/workflows/docs.yml` publishes tip-of-`main` rustdoc to
  https://doc.staticweaver.com/ via `actions/deploy-pages`. **No
  `gh-pages` branch exists** (GH-Pages-via-Actions only); both
  locally and on origin.

## Files changed

```
.github/workflows/ci.yml          |   8 +-
.github/workflows/docs.yml        |   8 +-
.github/workflows/release.yml     |   4 +-
CHANGELOG.md                      |  36 +++
Cargo.lock                        | 558 ++++++++++++++++--------------------
Cargo.toml                        |  16 +-
PERFORMANCE.md                    |  60 +++--
README.md                         |  15 +-
RELEASE_NOTES.md                  |  42 +++
src/context.rs                    | 130 ++++++++--
src/engine.rs                     | 258 +++++++++++++++++--
tests/lax_mode.rs                 | 133 +++++++++  (new)
tests/proptest_parser.rs          |  74 ++++++
```

## Validation

| Gate | Status |
| :--- | :--- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | clean |
| `cargo test --workspace --all-features` | 99 doctests + full suite green |
| `cargo build --bench comparative` (askama 0.16) | clean |
| `cargo +nightly rustdoc -- -Z unstable-options --show-coverage` | 100.0 % across all files |
| `cargo audit` | 0 advisories |
| `cargo publish --dry-run` | clean |
| Cross-platform CI matrix (macOS + Linux + Windows) | ✓ |
| Coverage gate (98 %) | ✓ |
| `Rust CI / Audit` | ✓ (was FAIL before this PR) |

## Issues closed by this PR

Closes #28, #30, #31, #32, #33, #34. Supersedes Dependabot PRs
#20, #21, #22, #23, #25, #26, #27 (all closed + branches deleted).
Addresses ssg#589 (downstream). RUSTSEC-2026-0185 remediated.

## Post-merge

```
git checkout main && git pull --ff-only
git tag -s v0.0.3 -m "v0.0.3"
git push origin v0.0.3                         # triggers release.yml → cargo publish
gh release create v0.0.3 --title "v0.0.3" --notes-from-tag
gh issue close 35 -c "Released as v0.0.3 on crates.io."
```

A wrapper lives at `.git/finalize-v0.0.3.sh`.