### PR TITLE
ci(release): publish to crates.io via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
-# Release pipeline. Fires on annotated `v*.*.*` tags and delegates to the
-# reusable workflow in `sebastienrousseau/pipelines`, which handles build,
-# SBOM, checksums, GitHub Release creation, and `cargo publish`.
+# Release pipeline. Fires on annotated `v*.*.*` tags. Verification,
+# `cargo publish` and SBOM/Sigstore signing all run inline here -- the
+# publish was moved out of the `sebastienrousseau/pipelines` reusable
+# workflow (see the comment above the publish job) and this header had
+# not been updated to match.
 #
 # Before pushing a tag:
 #   1. Update the `version` field in Cargo.toml and land it on `main`.
@@ -72,12 +74,22 @@ jobs:
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry-run) }}
     permissions:
       contents: read
+      # Mints the OIDC identity token crates.io exchanges for a
+      # short-lived publish token. Without it the auth step fails.
+      id-token: write
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      # Trusted publishing: swaps this job's GitHub OIDC identity for a
+      # temporary crates.io token, revoked by the action's post step when
+      # the job ends. Needs a trusted publisher on crates.io for the
+      # staticweaver crate (repo + release.yml).
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
       - name: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish
 
   # SBOM generation + Sigstore keyless signing (issue #44). Runs after


### PR DESCRIPTION
Replaces the stored CARGO_TOKEN with an OIDC exchange. crates.io issues
a short-lived token scoped to this crate and the auth action's post step
revokes it when the job ends. Nothing is stored, so there is nothing to
rotate and nothing to leak.

The publish job gains `id-token: write` alongside its existing
`contents: read`.

Requires a trusted publisher registered on crates.io for the
staticweaver crate: repository owner sebastienrousseau, workflow
release.yml, no environment. Releases here are tag-triggered, so merging
ahead of that configuration changes nothing until the next tag.

Also corrects the file header, which claimed the release delegates to
the reusable workflow in sebastienrousseau/pipelines. It no longer does
-- the publish was moved inline, as the comment above the publish job
already explained, but the header was never updated.

actionlint reports no new findings.


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)