### PR TITLE
fix(kani): stop the proof run failing on a phantom unused variable

### DIFF
--- a/tests/concurrent_render.rs
+++ b/tests/concurrent_render.rs
@@ -96,6 +96,12 @@ fn arc_engine_renders_identical_output_across_threads() {
 }
 
 #[test]
+// Kani substitutes its own `assert_eq!`, which discards the format
+// arguments. `id` is genuinely used below -- in the assertion message
+// -- so it is only unused when Kani rewrites the macro, and `-D
+// warnings` then fails the proof run on a warning that does not exist
+// in a normal build.
+#[cfg_attr(kani, allow(unused_variables))]
 fn arc_engine_renders_different_keys_in_parallel() {
     // Each thread renders with a distinct context — exercises the
     // cache-miss path concurrently. Per-thread output must match the


### PR DESCRIPTION
The `Kani` workflow has been red since **2026-08-23**, and not because a proof failed:

```
error: unused variable: `id`
error: could not compile `staticweaver` (test "concurrent_render") due to 1 previous error
error: Failed to execute cargo (exit status: 101). Found 1 compilation errors.
```

It never reached verification at all.

## Why the variable only looks unused

`id` *is* used — interpolated into the assertion message:

```rust
for (id, (ctx, expected)) in expected_per_thread.into_iter().enumerate() {
    ...
    assert_eq!(
        out, expected,
        "thread {id}: output must be deterministic under concurrency",
    );
```

Kani substitutes its own `assert_eq!`, which discards the format arguments. Under that rewrite the binding genuinely has no remaining use, and `-D warnings` turns it into a hard error — a warning that does not exist in an ordinary build.

## Fix

The allow is scoped to `cfg(kani)`, so normal builds keep warning if `id` ever becomes unused for real. Nothing about the test's behaviour changes.

## Verification

- `cargo test --test concurrent_render` — 6 passing
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Kani is not installed locally, so that path is verified by this PR's own workflow run rather than by me asserting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)